### PR TITLE
feat: email config + mailpit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,5 +39,14 @@ services:
   mq:
     image: rabbitmq:4.2-management
 
+  mailpit:
+    image: axllent/mailpit:v1.27
+    environment:
+      - MP_DISABLE_VERSION_CHECK=true
+      - MP_LABEL=ErrataMail
+    ports:
+      - "8825:8025"
+
+
 volumes:
   errata_data:

--- a/errata_project/settings/base.py
+++ b/errata_project/settings/base.py
@@ -137,7 +137,10 @@ CACHES = {
     }
 }
 
-# TODO configure the email system
+# email - disabled in base config
+EMAIL_BACKEND = "django.core.mail.backends.dummy.EmailBackend"
+DEFAULT_FROM_EMAIL = os.getenv("ERRATA_DEFAULT_FROM_EMAIL", "errata@rfc-editor.org")
+MESSAGE_ID_DOMAIN = "rfc-editor.org"
 
 ADMINS = [("Some Admin", "admin@example.org")]
 

--- a/errata_project/settings/dev.py
+++ b/errata_project/settings/dev.py
@@ -24,3 +24,8 @@ OIDC_OP_USER_ENDPOINT = "http://host.docker.internal:8000/api/openid/userinfo/"
 OIDC_OP_END_SESSION_ENDPOINT = "http://localhost:8000/api/openid/end-session/"
 
 DEPLOYMENT_MODE = "development"
+
+# email
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST = os.getenv("ERRATA_EMAIL_HOST", "mailpit")
+EMAIL_PORT = int(os.getenv("ERRATA_EMAIL_PORT", 1025))


### PR DESCRIPTION
Puts mailpit on http://localhost:8825/ so that it won't conflict with purple's use of port 8025