### PR TITLE
feat: blobstore

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: docker/errata.Dockerfile
-      target: app-dev
+#      target: app-dev
     init: true
     command: sleep infinity
     depends_on:
@@ -14,6 +14,8 @@ services:
     user: notroot
     volumes:
       - .:/workspace
+    ports:
+      - "8808:8808"
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
@@ -48,6 +50,18 @@ services:
     ports:
       - "8825:8025"
 
+  blobstore:
+    image: quay.io/minio/minio:latest
+    entrypoint: bash
+    command: -c "mkdir -p /data/errata && minio server /data --console-address :9002"
+    environment:
+      - MINIO_ROOT_USER=minioroot
+      - MINIO_ROOT_PASSWORD=miniopass
+    volumes:
+      - blob_data:/data
+    ports:
+      - "9002:9002" # dodge datatracker's use of 9001
 
 volumes:
   errata_data:
+  blob_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
   blobstore:
     image: quay.io/minio/minio:latest
     entrypoint: bash
-    command: -c "mkdir -p /data/errata && minio server /data --console-address :9002"
+    command: -c "mkdir -p /data/red && minio server /data --console-address :9002"
     environment:
       - MINIO_ROOT_USER=minioroot
       - MINIO_ROOT_PASSWORD=miniopass

--- a/errata_project/settings/base.py
+++ b/errata_project/settings/base.py
@@ -251,14 +251,7 @@ STORAGES = {
     },
     # Custom entries start here
     "blobstore": {
-        "BACKEND": "storages.backends.s3.S3Storage",
-        "OPTIONS": {
-            "bucket_name": "errata",
-            "endpoint_url": "http://blobstore:9000",
-            "access_key": "minioroot",
-            "secret_key": "miniopass",
-            "security_token": None,
-            "verify": False,
-        }
-    }
+        # dev / prod both replace this - this is a fallback for other situations
+        "BACKEND": "django.core.files.storage.InMemoryStorage",
+    },
 }

--- a/errata_project/settings/base.py
+++ b/errata_project/settings/base.py
@@ -239,3 +239,26 @@ CELERY_BEAT_SCHEDULER = "django_celery_beat.schedulers:DatabaseScheduler"
 CELERY_BEAT_SYNC_EVERY = 1  # update DB after every event
 # Window after after a missed deadline before abandoning a cron task
 CELERY_BEAT_CRON_STARTING_DEADLINE = 1800  # seconds
+
+# Storage
+STORAGES = {
+    # Django defaults
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+    # Custom entries start here
+    "blobstore": {
+        "BACKEND": "storages.backends.s3.S3Storage",
+        "OPTIONS": {
+            "bucket_name": "errata",
+            "endpoint_url": "http://blobstore:9000",
+            "access_key": "minioroot",
+            "secret_key": "miniopass",
+            "security_token": None,
+            "verify": False,
+        }
+    }
+}

--- a/errata_project/settings/base.py
+++ b/errata_project/settings/base.py
@@ -243,6 +243,7 @@ CELERY_BEAT_SYNC_EVERY = 1  # update DB after every event
 CELERY_BEAT_CRON_STARTING_DEADLINE = 1800  # seconds
 
 # Storage
+STORAGE_BUCKETS = ["red"]
 STORAGES = {
     # Django defaults
     "default": {
@@ -251,9 +252,11 @@ STORAGES = {
     "staticfiles": {
         "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
     },
+} | {
     # Custom entries start here
-    "blobstore": {
-        # dev / prod both replace this - this is a fallback for other situations
+    f"{bucket}_bucket": {
+        # dev / prod both replace these - this is a fallback for other situations
         "BACKEND": "django.core.files.storage.InMemoryStorage",
-    },
+    }
+    for bucket in BUCKETS
 }

--- a/errata_project/settings/base.py
+++ b/errata_project/settings/base.py
@@ -258,5 +258,5 @@ STORAGES = {
         # dev / prod both replace these - this is a fallback for other situations
         "BACKEND": "django.core.files.storage.InMemoryStorage",
     }
-    for bucket in BUCKETS
+    for bucket in STORAGE_BUCKETS
 }

--- a/errata_project/settings/dev.py
+++ b/errata_project/settings/dev.py
@@ -1,4 +1,6 @@
+# Copyright The IETF Trust 2025-2026, All Rights Reserved
 from .base import *  # noqa
+from .base import STORAGES
 import os
 
 DATABASES = {
@@ -39,4 +41,16 @@ DATATRACKER_RPC_API_TOKEN = "redtoken"  # not a real secret
 
 APP_API_TOKENS = {
     "errata.views.api_rfc_metadata_update": ["not a real secret"],
+}
+
+STORAGES["blobstore"] = {
+    "BACKEND": "storages.backends.s3.S3Storage",
+    "OPTIONS": {
+        "bucket_name": "errata",
+        "endpoint_url": "http://blobstore:9000",
+        "access_key": "minioroot",
+        "secret_key": "miniopass",
+        "security_token": None,
+        "verify": False,
+    },
 }

--- a/errata_project/settings/dev.py
+++ b/errata_project/settings/dev.py
@@ -43,14 +43,15 @@ APP_API_TOKENS = {
     "errata.views.api_rfc_metadata_update": ["not a real secret"],
 }
 
-STORAGES["blobstore"] = {
-    "BACKEND": "storages.backends.s3.S3Storage",
-    "OPTIONS": {
-        "bucket_name": "errata",
-        "endpoint_url": "http://blobstore:9000",
-        "access_key": "minioroot",
-        "secret_key": "miniopass",
-        "security_token": None,
-        "verify": False,
-    },
-}
+for _bucket in STORAGE_BUCKETS:
+    STORAGES[f"{_bucket}_bucket"] = {
+        "BACKEND": "storages.backends.s3.S3Storage",
+        "OPTIONS": {
+            "bucket_name": _bucket,
+            "endpoint_url": "http://blobstore:9000",
+            "access_key": "minioroot",
+            "secret_key": "miniopass",
+            "security_token": None,
+            "verify": False,
+        },
+    }

--- a/errata_project/settings/prod.py
+++ b/errata_project/settings/prod.py
@@ -111,7 +111,9 @@ if None in (_blob_store_endpoint_url, _blob_store_access_key, _blob_store_secret
         "All of ERRATA_BLOB_STORE_ENDPOINT_URL, ERRATA_BLOB_STORE_ACCESS_KEY, "
         "and ERRATA_BLOB_STORE_SECRET_KEY must be set"
     )
-_blob_store_bucket_prefix = os.environ.get("ERRATA_BLOB_STORE_BUCKET_PREFIX", "")
+_blob_store_bucket_name = os.environ.get(
+    "ERRATA_BLOB_STORE_BUCKET_NAME", "errata"
+).strip()
 _blob_store_max_attempts = int(os.environ.get("ERRATA_BLOB_STORE_MAX_ATTEMPTS", 5))
 _blob_store_connect_timeout = float(
     os.environ.get("ERRATA_BLOB_STORE_CONNECT_TIMEOUT", 10)
@@ -121,7 +123,7 @@ _blob_store_read_timeout = float(os.environ.get("ERRATA_BLOB_STORE_READ_TIMEOUT"
 STORAGES["blobstore"] = {
     "BACKEND": "storages.backends.s3.S3Storage",
     "OPTIONS": dict(
-        bucket_name=f"{_blob_store_bucket_prefix}errata".strip(),
+        bucket_name=_blob_store_bucket_name,
         endpoint_url=_blob_store_endpoint_url,
         access_key=_blob_store_access_key,
         secret_key=_blob_store_secret_key,

--- a/errata_project/settings/prod.py
+++ b/errata_project/settings/prod.py
@@ -111,31 +111,35 @@ if None in (_blob_store_endpoint_url, _blob_store_access_key, _blob_store_secret
         "All of ERRATA_BLOB_STORE_ENDPOINT_URL, ERRATA_BLOB_STORE_ACCESS_KEY, "
         "and ERRATA_BLOB_STORE_SECRET_KEY must be set"
     )
-_blob_store_bucket_name = os.environ.get(
-    "ERRATA_BLOB_STORE_BUCKET_NAME", "errata"
-).strip()
+
 _blob_store_max_attempts = int(os.environ.get("ERRATA_BLOB_STORE_MAX_ATTEMPTS", 5))
 _blob_store_connect_timeout = float(
     os.environ.get("ERRATA_BLOB_STORE_CONNECT_TIMEOUT", 10)
 )
 _blob_store_read_timeout = float(os.environ.get("ERRATA_BLOB_STORE_READ_TIMEOUT", 10))
 
-STORAGES["blobstore"] = {
-    "BACKEND": "storages.backends.s3.S3Storage",
-    "OPTIONS": dict(
-        bucket_name=_blob_store_bucket_name,
-        endpoint_url=_blob_store_endpoint_url,
-        access_key=_blob_store_access_key,
-        secret_key=_blob_store_secret_key,
-        security_token=None,
-        client_config=botocore.config.Config(
-            request_checksum_calculation="when_required",
-            response_checksum_validation="when_required",
-            signature_version="s3v4",
-            connect_timeout=_blob_store_connect_timeout,
-            read_timeout=_blob_store_read_timeout,
-            retries={"total_max_attempts": _blob_store_max_attempts},
+for _bucket in STORAGE_BUCKETS:
+    # expect env var like ERRATA_BLOB_STORE_BUCKET_NAME_RED
+    _envvar = f"ERRATA_BLOB_STORE_BUCKET_NAME_{_bucket.upper()}"
+    _blob_store_bucket_name = os.environ.get(_envvar, None).strip()
+    if _blob_store_bucket_name is None:
+        raise RuntimeError(f"{_envvar} must be set")
+    STORAGES[f"{_bucket}_bucket"] = {
+        "BACKEND": "storages.backends.s3.S3Storage",
+        "OPTIONS": dict(
+            bucket_name=_blob_store_bucket_name,
+            endpoint_url=_blob_store_endpoint_url,
+            access_key=_blob_store_access_key,
+            secret_key=_blob_store_secret_key,
+            security_token=None,
+            client_config=botocore.config.Config(
+                request_checksum_calculation="when_required",
+                response_checksum_validation="when_required",
+                signature_version="s3v4",
+                connect_timeout=_blob_store_connect_timeout,
+                read_timeout=_blob_store_read_timeout,
+                retries={"total_max_attempts": _blob_store_max_attempts},
+            ),
+            verify=False,
         ),
-        verify=False,
-    ),
-}
+    }

--- a/errata_project/settings/prod.py
+++ b/errata_project/settings/prod.py
@@ -1,4 +1,8 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+import botocore.config
+
 from .base import *  # noqa
+from .base import STORAGES
 from email.utils import parseaddr
 import json
 import os
@@ -95,3 +99,41 @@ if _admins_str is not None:
     ADMINS = [parseaddr(admin) for admin in _multiline_to_list(_admins_str)]
 else:
     raise RuntimeError("ERRATA_ADMINS must be set")
+
+
+# Storages configuration
+# Configure storages for the replica blob store
+_blob_store_endpoint_url = os.environ.get("ERRATA_BLOB_STORE_ENDPOINT_URL")
+_blob_store_access_key = os.environ.get("ERRATA_BLOB_STORE_ACCESS_KEY")
+_blob_store_secret_key = os.environ.get("ERRATA_BLOB_STORE_SECRET_KEY")
+if None in (_blob_store_endpoint_url, _blob_store_access_key, _blob_store_secret_key):
+    raise RuntimeError(
+        "All of ERRATA_BLOB_STORE_ENDPOINT_URL, ERRATA_BLOB_STORE_ACCESS_KEY, "
+        "and ERRATA_BLOB_STORE_SECRET_KEY must be set"
+    )
+_blob_store_bucket_prefix = os.environ.get("ERRATA_BLOB_STORE_BUCKET_PREFIX", "")
+_blob_store_max_attempts = int(os.environ.get("ERRATA_BLOB_STORE_MAX_ATTEMPTS", 5))
+_blob_store_connect_timeout = float(
+    os.environ.get("ERRATA_BLOB_STORE_CONNECT_TIMEOUT", 10)
+)
+_blob_store_read_timeout = float(os.environ.get("ERRATA_BLOB_STORE_READ_TIMEOUT", 10))
+
+STORAGES["blobstore"] = {
+    "BACKEND": "storages.backends.s3.S3Storage",
+    "OPTIONS": dict(
+        bucket_name=f"{_blob_store_bucket_prefix}errata".strip(),
+        endpoint_url=_blob_store_endpoint_url,
+        access_key=_blob_store_access_key,
+        secret_key=_blob_store_secret_key,
+        security_token=None,
+        client_config=botocore.config.Config(
+            request_checksum_calculation="when_required",
+            response_checksum_validation="when_required",
+            signature_version="s3v4",
+            connect_timeout=_blob_store_connect_timeout,
+            read_timeout=_blob_store_read_timeout,
+            retries={"total_max_attempts": _blob_store_max_attempts},
+        ),
+        verify=False,
+    ),
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ celery>=5.5.3
 Django~=5.2
 django-bootstrap5>=25.1
 django-celery-beat>=2.8.1
+django-storages[s3]>=1.14.6
 gunicorn>=25.0.0
 python-json-logger>=4.0.0
 mozilla-django-oidc>=4,<5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ./openapi/rpcapi_client
+botocore>=1.42.57
 celery>=5.5.3
 Django~=5.2
 django-bootstrap5>=25.1


### PR DESCRIPTION
Adds a single S3-backed storage, "red_bucket". Adds a minio instance for dev with a console available on port 9002.

A quick way to test:
```python
import io
from django.core.files.storage import storages
red_bucket = storages["red_bucket"]

red_bucket.save("my-test.txt", io.StringIO("my file contents"))

with red_bucket.open("my-test.txt", "r") as f:
    print(f.read())

red_bucket.delete("my-test.txt")
```

We'll need to provision credentials and update secrets for staging before deploying this.